### PR TITLE
Change homedir user name to defaultuser and default SFOS version to 4.2.0.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM coderus/sailfishos-platform-sdk:3.3.0.14
+FROM coderus/sailfishos-platform-sdk:4.0.2.21
 
 ADD build.sh /home/nemo/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM coderus/sailfishos-platform-sdk:4.0.2.21
 
-ADD build.sh /home/nemo/
+ADD build.sh /home/mersdk/
 
-ENV HOME=/home/nemo
+ENV HOME=/home/mersdk
 
 RUN set -ex ;\
-  mkdir -p /home/nemo/build ;\
-  sudo chmod +x /home/nemo/build.sh
+  mkdir -p /home/mersdk/build ;\
+  sudo chmod +x /home/mersdk/build.sh
 
-ENTRYPOINT ["/home/nemo/build.sh"]
+ENTRYPOINT ["/home/mersdk/build.sh"]

--- a/action.yml
+++ b/action.yml
@@ -5,14 +5,14 @@ inputs:
   release:
     description: 'SailfishOS release (check https://hub.docker.com/r/coderus/sailfishos-platform-sdk/tags)'
     required: true
-    default: 3.3.0.14
+    default: 4.0.2.21
   arch:
     description: 'Build arch (e.g. armv7hl, i486)'
     default: 'armv7hl'
 
 runs:
   using: 'composite'
-  steps: 
+  steps:
     - run: bash -ex $GITHUB_ACTION_PATH/build.sh
       shell: bash
       env:

--- a/docker.sh
+++ b/docker.sh
@@ -2,11 +2,11 @@
 
 set -ex
 
-mkdir -p /home/nemo/build
-cd /home/nemo/build
+mkdir -p /home/mersdk/build
+cd /home/mersdk/build
 
 sudo mkdir -p /workspace/RPMS
-cp -r /workspace/* /home/nemo/build
+cp -r /workspace/* /home/mersdk/build
 
 mb2 -t SailfishOS-${INPUT_RELEASE}-${INPUT_ARCH} build
 sudo cp -r RPMS/*.rpm /workspace/RPMS

--- a/pre.sh
+++ b/pre.sh
@@ -2,4 +2,4 @@
 
 set -ex
 
-mkdir -p /home/nemo/build
+mkdir -p /home/mersdk/build


### PR DESCRIPTION
Fix action on 4.2.0.21: https://github.com/llewelld/harbour-contrac/runs/4116849364?check_suite_focus=true

I first wanted to introduce some if-else handling both the old and the new cases, but I think it's better for this to stay as simple as possible. People who need the older version can just tag the old commit ID in their `workflow.yaml`