### PR TITLE
Fix non-existent default 4.0.2.21→4.1.0.24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ inputs:
   release:
     description: 'SailfishOS release (check https://hub.docker.com/r/coderus/sailfishos-platform-sdk/tags)'
     required: true
-    default: 4.0.2.21
+    default: 4.1.0.24
   arch:
     description: 'Build arch (e.g. armv7hl, i486)'
     default: 'armv7hl'


### PR DESCRIPTION
… because 4.1.0.23 and 4.1.0.24 are the smallest docker images which still work, see issue #3.