### PR TITLE
Fix non-existent default 4.0.2.21→4.1.0.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM coderus/sailfishos-platform-sdk:4.0.2.21
+FROM coderus/sailfishos-platform-sdk:4.1.0.24
 
 ADD build.sh /home/mersdk/
 


### PR DESCRIPTION
… because 4.1.0.23 and 4.1.0.24 are the smallest docker images which still work, see issue #3.