### PR TITLE
Fix build when RPMS doesn't exist

### DIFF
--- a/docker.sh
+++ b/docker.sh
@@ -6,4 +6,5 @@ mkdir -p build
 cd build
 cp -r /workspace/* .
 mb2 -t SailfishOS-${INPUT_RELEASE}-${INPUT_ARCH} build
+sudo mkdir -p /workspace/RPMS
 sudo cp -r RPMS/*.rpm /workspace/RPMS


### PR DESCRIPTION
I've tried to use your GitHub actions (thanks!), but [it failed](https://github.com/ilpianista/harbour-Papocchio/actions/runs/3543847877/jobs/5950644866#step:18:50) with:

```
error: failed to create directory %{_rpmdir}: /home/mersdk/build/RPMS: No such file or directory
```

It turns out that when `/workspace/RPMS` doesn't exist, the `cp RPMS/*.rpm` creates a file `/workspace/RPMS` and the next build fails to create the RPMS dir.